### PR TITLE
Add emphemeral browser option iOS/Catalyst user agents.

### DIFF
--- a/Source/AppAuth/iOS/OIDAuthState+IOS.h
+++ b/Source/AppAuth/iOS/OIDAuthState+IOS.h
@@ -50,6 +50,31 @@ NS_ASSUME_NONNULL_BEGIN
                      presentingViewController:(UIViewController *)presentingViewController
                                      callback:(OIDAuthStateAuthorizationCallback)callback;
 
+/*! @brief Convenience method to create a @c OIDAuthState by presenting an authorization request
+        (optionally using an emphemeral browser session that shares no cookies or data with the
+        normal browser session) and performing the authorization code exchange in the case of code
+        flow requests. For the hybrid flow, the caller should validate the id_token and c_hash, then
+        perform the token request (@c OIDAuthorizationService.performTokenRequest:callback:)
+        and update the OIDAuthState with the results (@c
+        OIDAuthState.updateWithTokenResponse:error:).
+    @param authorizationRequest The authorization request to present.
+    @param presentingViewController The view controller from which to present the
+        @c SFSafariViewController. On iOS 13, the window of this UIViewController
+        is used as the ASPresentationAnchor.
+    @param prefersEphemeralSession Whether the caller prefers to use a private authentication
+        session. See @c ASWebAuthenticationSession.prefersEphemeralWebBrowserSession for more.
+    @param callback The method called when the request has completed or failed.
+    @return A @c OIDExternalUserAgentSession instance which will terminate when it
+        receives a @c OIDExternalUserAgentSession.cancel message, or after processing a
+        @c OIDExternalUserAgentSession.resumeExternalUserAgentFlowWithURL: message.
+ */
++ (id<OIDExternalUserAgentSession>)
+    authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
+                     presentingViewController:(UIViewController *)presentingViewController
+                      prefersEphemeralSession:(BOOL)prefersEphemeralSession
+                                     callback:(OIDAuthStateAuthorizationCallback)callback
+    API_AVAILABLE(ios(13));
+
 + (id<OIDExternalUserAgentSession>)
     authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
                      callback:(OIDAuthStateAuthorizationCallback)callback API_AVAILABLE(ios(11)) API_UNAVAILABLE(macCatalyst)

--- a/Source/AppAuth/iOS/OIDAuthState+IOS.m
+++ b/Source/AppAuth/iOS/OIDAuthState+IOS.m
@@ -42,6 +42,26 @@
                                                 callback:callback];
 }
 
++ (id<OIDExternalUserAgentSession>)
+    authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest
+                     presentingViewController:(UIViewController *)presentingViewController
+                      prefersEphemeralSession:(BOOL)prefersEphemeralSession
+                                     callback:(OIDAuthStateAuthorizationCallback)callback {
+  id<OIDExternalUserAgent> externalUserAgent;
+#if TARGET_OS_MACCATALYST
+  externalUserAgent = [[OIDExternalUserAgentCatalyst alloc]
+          initWithPresentingViewController:presentingViewController
+                   prefersEphemeralSession:prefersEphemeralSession];
+#else // TARGET_OS_MACCATALYST
+  externalUserAgent = [[OIDExternalUserAgentIOS alloc]
+          initWithPresentingViewController:presentingViewController
+                   prefersEphemeralSession:prefersEphemeralSession];
+#endif // TARGET_OS_MACCATALYST
+  return [self authStateByPresentingAuthorizationRequest:authorizationRequest
+                                       externalUserAgent:externalUserAgent
+                                                callback:callback];
+}
+
 #if !TARGET_OS_MACCATALYST
 + (id<OIDExternalUserAgentSession>)
     authStateByPresentingAuthorizationRequest:(OIDAuthorizationRequest *)authorizationRequest

--- a/Source/AppAuth/iOS/OIDAuthorizationService+IOS.h
+++ b/Source/AppAuth/iOS/OIDAuthorizationService+IOS.h
@@ -43,6 +43,24 @@ NS_ASSUME_NONNULL_BEGIN
 + (id<OIDExternalUserAgentSession>) presentAuthorizationRequest:(OIDAuthorizationRequest *)request
     presentingViewController:(UIViewController *)presentingViewController
                     callback:(OIDAuthorizationCallback)callback;
+
+/*! @brief Perform an authorization flow using the @c ASWebAuthenticationSession optionally using an
+        emphemeral browser session that shares no cookies or data with the normal browser session.
+    @param request The authorization request.
+    @param presentingViewController The view controller from which to present the
+        \SFSafariViewController.
+    @param prefersEphemeralSession Whether the caller prefers to use a private authentication
+        session. See @c ASWebAuthenticationSession.prefersEphemeralWebBrowserSession for more.
+    @param callback The method called when the request has completed or failed.
+    @return A @c OIDExternalUserAgentSession instance which will terminate when it
+        receives a @c OIDExternalUserAgentSession.cancel message, or after processing a
+        @c OIDExternalUserAgentSession.resumeExternalUserAgentFlowWithURL: message.
+ */
++ (id<OIDExternalUserAgentSession>) presentAuthorizationRequest:(OIDAuthorizationRequest *)request
+    presentingViewController:(UIViewController *)presentingViewController
+     prefersEphemeralSession:(BOOL)prefersEphemeralSession
+                    callback:(OIDAuthorizationCallback)callback API_AVAILABLE(ios(13));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/AppAuth/iOS/OIDAuthorizationService+IOS.m
+++ b/Source/AppAuth/iOS/OIDAuthorizationService+IOS.m
@@ -41,6 +41,22 @@ NS_ASSUME_NONNULL_BEGIN
   return [self presentAuthorizationRequest:request externalUserAgent:externalUserAgent callback:callback];
 }
 
++ (id<OIDExternalUserAgentSession>) presentAuthorizationRequest:(OIDAuthorizationRequest *)request
+    presentingViewController:(UIViewController *)presentingViewController
+     prefersEphemeralSession:(BOOL)prefersEphemeralSession
+                    callback:(OIDAuthorizationCallback)callback {
+  id<OIDExternalUserAgent> externalUserAgent;
+#if TARGET_OS_MACCATALYST
+  externalUserAgent = [[OIDExternalUserAgentCatalyst alloc]
+      initWithPresentingViewController:presentingViewController
+                       prefersEphemeralSession:prefersEphemeralSession];
+#else // TARGET_OS_MACCATALYST
+  externalUserAgent = [[OIDExternalUserAgentIOS alloc] initWithPresentingViewController:presentingViewController
+               prefersEphemeralSession:prefersEphemeralSession];
+#endif // TARGET_OS_MACCATALYST
+  return [self presentAuthorizationRequest:request externalUserAgent:externalUserAgent callback:callback];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/AppAuth/iOS/OIDExternalUserAgentCatalyst.h
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentCatalyst.h
@@ -45,6 +45,15 @@ API_AVAILABLE(macCatalyst(13)) API_UNAVAILABLE(ios)
     (UIViewController *)presentingViewController
     NS_DESIGNATED_INITIALIZER;
 
+/*! @brief Create a Catalyst user-agent which optionally uses a private authentication session.
+    @param presentingViewController The view controller from which to present the browser.
+    @param prefersEphemeralSession Whether the caller prefers to use a private authentication
+        session. See @c ASWebAuthenticationSession.prefersEphemeralWebBrowserSession for more.
+ */
+- (nullable instancetype)initWithPresentingViewController:
+    (UIViewController *)presentingViewController
+                                  prefersEphemeralSession:(BOOL)prefersEphemeralSession;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/AppAuth/iOS/OIDExternalUserAgentCatalyst.m
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentCatalyst.m
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation OIDExternalUserAgentCatalyst {
   UIViewController *_presentingViewController;
+  BOOL _prefersEphemeralSession;
 
   BOOL _externalUserAgentFlowInProgress;
   __weak id<OIDExternalUserAgentSession> _session;
@@ -49,6 +50,16 @@ NS_ASSUME_NONNULL_BEGIN
   self = [super init];
   if (self) {
     _presentingViewController = presentingViewController;
+  }
+  return self;
+}
+
+- (nullable instancetype)initWithPresentingViewController:
+    (UIViewController *)presentingViewController
+                                  prefersEphemeralSession:(BOOL)prefersEphemeralSession {
+  self = [self initWithPresentingViewController:presentingViewController];
+  if (self) {
+    _prefersEphemeralSession = prefersEphemeralSession;
   }
   return self;
 }
@@ -89,6 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
   }];
       
   authenticationVC.presentationContextProvider = self;
+  authenticationVC.prefersEphemeralWebBrowserSession = _prefersEphemeralSession;
   _webAuthenticationVC = authenticationVC;
   openedUserAgent = [authenticationVC start];
 

--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.h
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.h
@@ -46,6 +46,16 @@ API_UNAVAILABLE(macCatalyst)
     (UIViewController *)presentingViewController
     NS_DESIGNATED_INITIALIZER;
 
+/*! @brief Create an iOS user-agent which optionally uses a private authentication session.
+    @param presentingViewController The view controller from which to present the browser.
+    @param prefersEphemeralSession Whether the caller prefers to use a private authentication
+        session. See @c ASWebAuthenticationSession.prefersEphemeralWebBrowserSession for more.
+ */
+- (nullable instancetype)initWithPresentingViewController:
+    (UIViewController *)presentingViewController
+                                  prefersEphemeralSession:(BOOL)prefersEphemeralSession
+    API_AVAILABLE(ios(13));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
+++ b/Source/AppAuth/iOS/OIDExternalUserAgentIOS.m
@@ -43,6 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation OIDExternalUserAgentIOS {
   UIViewController *_presentingViewController;
+  BOOL _prefersEphemeralSession;
 
   BOOL _externalUserAgentFlowInProgress;
   __weak id<OIDExternalUserAgentSession> _session;
@@ -71,6 +72,16 @@ NS_ASSUME_NONNULL_BEGIN
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     
     _presentingViewController = presentingViewController;
+  }
+  return self;
+}
+
+- (nullable instancetype)initWithPresentingViewController:
+    (UIViewController *)presentingViewController
+                                  prefersEphemeralSession:(BOOL)prefersEphemeralSession {
+  self = [self initWithPresentingViewController:presentingViewController];
+  if (self) {
+    _prefersEphemeralSession = prefersEphemeralSession;
   }
   return self;
 }
@@ -115,7 +126,8 @@ NS_ASSUME_NONNULL_BEGIN
       }];
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
       if (@available(iOS 13.0, *)) {
-          authenticationVC.presentationContextProvider = self;
+        authenticationVC.presentationContextProvider = self;
+        authenticationVC.prefersEphemeralWebBrowserSession = _prefersEphemeralSession;
       }
 #endif
       _webAuthenticationVC = authenticationVC;


### PR DESCRIPTION
Adds BOOL properties to iOS/Catalyst-related methods which allow setting the ASWebAuthenticationSession property prefersEphemeralWebBrowserSession.

ref: https://github.com/openid/AppAuth-iOS/pull/645